### PR TITLE
Persist template-generated notes

### DIFF
--- a/src/stores/simpleStore.ts
+++ b/src/stores/simpleStore.ts
@@ -444,6 +444,9 @@ Created: {{date}}`,
               throw new Error('Generated note is invalid')
             }
 
+            // Persist the newly created note
+            storageService.saveNote(newNote)
+
             return {
               notes: [newNote, ...state.notes],
               currentNote: newNote,


### PR DESCRIPTION
## Summary
- save notes created from templates to localStorage so they persist

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68706d95778c8322b49e656f864a42ae